### PR TITLE
Implement compatibility with Python 3.10

### DIFF
--- a/nuxhash/gui/about.py
+++ b/nuxhash/gui/about.py
@@ -20,7 +20,7 @@ class AboutScreen(wx.Panel):
         h_sizer = wx.BoxSizer(orient=wx.HORIZONTAL)
         self.SetSizer(h_sizer)
         v_sizer = wx.BoxSizer(orient=wx.VERTICAL)
-        h_sizer.Add(v_sizer, wx.SizerFlags().Proportion(1.0)
+        h_sizer.Add(v_sizer, wx.SizerFlags().Proportion(1)
                                             .Align(wx.ALIGN_CENTER))
 
         with open(LOGO_PATH, 'rb') as f:

--- a/nuxhash/gui/benchmarks.py
+++ b/nuxhash/gui/benchmarks.py
@@ -53,7 +53,7 @@ class BenchmarksScreen(wx.Panel):
         innerWindow.SetupScrolling()
         sizer.Add(innerWindow, wx.SizerFlags().Border(wx.LEFT|wx.RIGHT|wx.TOP,
                                                       main.PADDING_PX)
-                                              .Proportion(1.0)
+                                              .Proportion(1)
                                               .Expand())
         innerSizer = wx.BoxSizer(orient=wx.VERTICAL)
         innerWindow.SetSizer(innerSizer)

--- a/nuxhash/gui/mining.py
+++ b/nuxhash/gui/mining.py
@@ -54,13 +54,13 @@ class MiningScreen(wx.Panel):
         # Update balance periodically.
         self._Timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self._OnBalanceTimer, self._Timer)
-        self._Timer.Start(milliseconds=BALANCE_UPDATE_MIN*60*1e3)
+        self._Timer.Start(milliseconds=BALANCE_UPDATE_MIN*60*1000)
 
         # Add mining panel.
         self._Panel = MiningPanel(self, style=wx.dataview.DV_HORIZ_RULES)
         sizer.Add(self._Panel, wx.SizerFlags().Border(wx.LEFT|wx.RIGHT|wx.TOP,
                                                       main.PADDING_PX)
-                                              .Proportion(1.0)
+                                              .Proportion(1)
                                               .Expand())
 
         bottomSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
@@ -70,7 +70,7 @@ class MiningScreen(wx.Panel):
         # Add balance displays.
         balances = wx.FlexGridSizer(2, 2, main.PADDING_PX)
         balances.AddGrowableCol(1)
-        bottomSizer.Add(balances, wx.SizerFlags().Proportion(1.0).Expand())
+        bottomSizer.Add(balances, wx.SizerFlags().Proportion(1).Expand())
 
         balances.Add(wx.StaticText(self, label='Daily revenue'))
         self._Revenue = wx.StaticText(

--- a/nuxhash/gui/settings.py
+++ b/nuxhash/gui/settings.py
@@ -192,7 +192,7 @@ class SettingsScreen(wx.Panel):
         self._ApiKey.SetValue(self._Settings['nicehash']['api_key'])
         self._ApiSecret.SetValue(self._Settings['nicehash']['api_secret'])
         self._Interval.SetValue(self._Settings['switching']['interval'])
-        self._Threshold.SetValue(self._Settings['switching']['threshold']*100)
+        self._Threshold.SetValue(int(self._Settings['switching']['threshold']*100))
         self._Units.SetValue(self._Settings['gui']['units'])
         self._Revert.Disable()
         self._Save.Disable()


### PR DESCRIPTION
In Python 3.10, the way in which type hints were treated was changed, so these changes account for that.